### PR TITLE
Fixed references to old logging library to make tests pass

### DIFF
--- a/neutron_lbaas/tests/tempest/v2/api/base.py
+++ b/neutron_lbaas/tests/tempest/v2/api/base.py
@@ -21,11 +21,11 @@ from neutron_lbaas.tests.tempest.v2.clients import load_balancers_client
 from neutron_lbaas.tests.tempest.v2.clients import members_client
 from neutron_lbaas.tests.tempest.v2.clients import pools_client
 
+from oslo_log import log as logging
 from tempest.api.network import base
 from tempest import clients as tempest_clients
 from tempest import config
 from tempest import exceptions
-from tempest.openstack.common import log as logging
 
 CONF = config.CONF
 

--- a/neutron_lbaas/tests/tempest/v2/api/test_listeners.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_listeners.py
@@ -15,10 +15,10 @@
 
 from neutron_lbaas.tests.tempest.v2.api import base
 
+from oslo_log import log as logging
 from tempest.common.utils import data_utils
 from tempest import config
 from tempest import exceptions
-from tempest.openstack.common import log as logging
 from tempest import test
 
 CONF = config.CONF

--- a/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_admin.py
@@ -13,9 +13,9 @@
 # under the License.
 
 from neutron_lbaas.tests.tempest.v2.api import base
+from oslo_log import log as logging
 from tempest.common.utils import data_utils
 from tempest import config
-from tempest.openstack.common import log as logging
 from tempest import test
 
 CONF = config.CONF

--- a/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_load_balancers_non_admin.py
@@ -16,10 +16,10 @@
 from netaddr import IPAddress
 
 from neutron_lbaas.tests.tempest.v2.api import base
+from oslo_log import log as logging
 from tempest.common.utils import data_utils
 from tempest import config
 from tempest import exceptions
-from tempest.openstack.common import log as logging
 from tempest import test
 
 CONF = config.CONF

--- a/neutron_lbaas/tests/tempest/v2/api/test_members.py
+++ b/neutron_lbaas/tests/tempest/v2/api/test_members.py
@@ -14,10 +14,10 @@
 #    under the License.
 from neutron_lbaas.tests.tempest.v2.api import base
 
+from oslo_log import log as logging
 from tempest.common.utils import data_utils
 from tempest import config
 from tempest import exceptions as ex
-from tempest.openstack.common import log as logging
 from tempest import test
 
 CONF = config.CONF


### PR DESCRIPTION
Replaced tempest.openstack.common with oslo_log